### PR TITLE
fix unable to set outputs

### DIFF
--- a/OXRS-SHA-StateController-ESP32-FW.ino
+++ b/OXRS-SHA-StateController-ESP32-FW.ino
@@ -294,7 +294,7 @@ void jsonCommand(JsonVariant json)
   {
     for (JsonVariant output : json["outputs"].as<JsonArray>())
     {
-      jsonOutputConfig(output);
+      jsonOutputCommand(output);
     }
   }
 }


### PR DESCRIPTION
corrected typo in callback   jsonCommand(JsonVariant json)
closes #7 