### PR TITLE
rename of setDisplayPorts()  to setDisplayPortLayout() in Rack32  not updated

### DIFF
--- a/OXRS-SHA-StateController-ESP32-FW.ino
+++ b/OXRS-SHA-StateController-ESP32-FW.ino
@@ -101,11 +101,11 @@ void setup()
   // Set up port display
   if (g_mcp_output_pins == 8)
   {
-    rack32.setDisplayPorts(g_mcps_found, PORT_LAYOUT_OUTPUT_AUTO_8);
+    rack32.setDisplayPortLayout(g_mcps_found, PORT_LAYOUT_OUTPUT_AUTO_8);
   }
   else
   {
-    rack32.setDisplayPorts(g_mcps_found, PORT_LAYOUT_OUTPUT_AUTO);
+    rack32.setDisplayPortLayout(g_mcps_found, PORT_LAYOUT_OUTPUT_AUTO);
   }
 
   // Set up config/command schemas (for self-discovery and adoption)


### PR DESCRIPTION
the change in Rack32 V 1.6.0 where setDisplayPorts() was renamed to setDisplayPortLayout() was not updated in StateController